### PR TITLE
Provided documentation links in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
-# utility-package
-Various go utilities we can use for development of (including, but not limited to) discord code.
+# Utility-package
+Various go utilities we can use for development of (including, but not limited to) discord code.  
+  
+  
+## Documentation
+- **Botutil**  
+  - [Code](https://github.com/Floor-Gang/utilpkg/tree/production/botutil)  
+  - [Documentation](https://godoc.org/github.com/Floor-Gang/utilpkg/botutil)    
+  
+- **Config**  
+  - [Code](https://github.com/Floor-Gang/utilpkg/tree/production/config)  
+  - [Documentation](https://godoc.org/github.com/Floor-Gang/utilpkg/config)  
+    
+- **Db**  
+  - [Code](https://github.com/Floor-Gang/utilpkg/tree/production/db)  
+  - [Documentation](https://godoc.org/github.com/Floor-Gang/utilpkg/db)  
+    
+- **Logger**
+  - [Code](https://github.com/Floor-Gang/utilpkg/tree/production/logger)  
+  - [Documentation](https://godoc.org/github.com/Floor-Gang/utilpkg/logger)  
+    
+- **Streams**
+  - [Code](https://github.com/Floor-Gang/utilpkg/blob/production/streams)  
+  - [Documentation](https://godoc.org/github.com/Floor-Gang/utilpkg/streams)  
+    
+- **Stringutils**
+  - [Code](https://github.com/Floor-Gang/utilpkg/blob/production/stringutil)  
+  - [Documentation](https://godoc.org/github.com/Floor-Gang/utilpkg/stringutil)    
+  


### PR DESCRIPTION
Godoc auto-generates documentation.

Since we are using multiple package names I thought it'd be a nice touch to have all the documentation links in one place.